### PR TITLE
Add navigation bar and corresponding fragments

### DIFF
--- a/BibBuddy/.idea/gradle.xml
+++ b/BibBuddy/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/BibBuddy/app/build.gradle
+++ b/BibBuddy/app/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation "androidx.fragment:fragment:1.2.5"
+
+
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/BibBuddy/app/src/main/AndroidManifest.xml
+++ b/BibBuddy/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.BibBuddy">
+
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -16,6 +17,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/BibBuddy/app/src/main/java/de/bibbuddy/HomeFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/HomeFragment.java
@@ -1,0 +1,24 @@
+package de.bibbuddy;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+public class HomeFragment extends Fragment {
+
+//   public HomeFragment() {
+//      super(R.layout.fragment_home);
+//   }
+   @Nullable
+   @Override
+   public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+      View view = inflater.inflate(R.layout.fragment_home,container,false);
+      return view;
+   }
+}
+

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -1,0 +1,24 @@
+package de.bibbuddy;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+public class LibraryFragment extends Fragment {
+
+//   public LibraryFragment() {
+//      super(R.layout.fragment_library);
+//   }
+   @Nullable
+   @Override
+   public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+      View view = inflater.inflate(R.layout.fragment_library,container,false);
+      return view;
+   }
+}
+

--- a/BibBuddy/app/src/main/java/de/bibbuddy/MainActivity.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/MainActivity.java
@@ -1,15 +1,89 @@
 package de.bibbuddy;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.os.Bundle;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
+
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
 public class MainActivity extends AppCompatActivity {
+
+   BottomNavigationView bottomNavigationView;
+   FragmentManager fragmentManager;
+
+   private HomeFragment homeFragment;
+   private final String HOME_FRAGMENT_TAG = "home";
+
+   private SearchFragment searchFragment;
+   private final String SEARCH_FRAGMENT_TAG = "search";
+
+   private LibraryFragment libraryFragment;
+   private final String LIBRARY_FRAGMENT_TAG = "library";
+
+   private NotesFragment notesFragment;
+   private final String NOTES_FRAGMENT_TAG = "notes";
+
 
    @Override
    protected void onCreate(Bundle savedInstanceState) {
       super.onCreate(savedInstanceState);
       setContentView(R.layout.activity_main);
+
+      bottomNavigationView = (BottomNavigationView) findViewById(R.id.navigation_bar);
+      fragmentManager = getSupportFragmentManager();
+
+      if (savedInstanceState == null) {
+         homeFragment = new HomeFragment();
+         updateFragment(R.id.fragment_container_view, homeFragment, HOME_FRAGMENT_TAG);
+      }
+
+      setupBottomNavigationView();
    }
-   // Home Search Library Notes
+
+   private void setupBottomNavigationView() {
+      bottomNavigationView.setOnNavigationItemSelectedListener(item -> {
+         switch (item.getItemId()) {
+            case R.id.navigation_home:
+               if (homeFragment == null) {
+                  homeFragment = new HomeFragment();
+               }
+               updateFragment(R.id.fragment_container_view, homeFragment, HOME_FRAGMENT_TAG);
+               break;
+
+            case R.id.navigation_search:
+               if (searchFragment == null) {
+                  searchFragment = new SearchFragment();
+               }
+               updateFragment(R.id.fragment_container_view, searchFragment, SEARCH_FRAGMENT_TAG);
+               break;
+
+            case R.id.navigation_library:
+               if (libraryFragment == null) {
+                  libraryFragment = new LibraryFragment();
+               }
+               updateFragment(R.id.fragment_container_view, libraryFragment, LIBRARY_FRAGMENT_TAG);
+               break;
+
+            case R.id.navigation_notes:
+               if (notesFragment == null) {
+                  notesFragment = new NotesFragment();
+               }
+               updateFragment(R.id.fragment_container_view, notesFragment, NOTES_FRAGMENT_TAG);
+               break;
+         }
+         
+         return true;
+      });
+   }
+
+   private void updateFragment(int id, Fragment fragment, String tag) {
+      FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+      fragmentTransaction.replace(id, fragment, tag);
+      fragmentTransaction.setReorderingAllowed(true);
+      fragmentTransaction.addToBackStack(null);
+      fragmentTransaction.commit();
+   }
 }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NotesFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NotesFragment.java
@@ -1,0 +1,24 @@
+package de.bibbuddy;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+public class NotesFragment extends Fragment {
+
+//   public NotesFragment() {
+//      super(R.layout.fragment_notes);
+//   }
+   @Nullable
+   @Override
+   public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+      View view = inflater.inflate(R.layout.fragment_notes,container,false);
+      return view;
+   }
+}
+

--- a/BibBuddy/app/src/main/java/de/bibbuddy/SearchFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/SearchFragment.java
@@ -1,0 +1,25 @@
+package de.bibbuddy;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+public class SearchFragment extends Fragment {
+
+   // public SearchFragment() {
+//      super(R.layout.fragment_search);
+//   }
+   @Nullable
+   @Override
+   public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+      View view = inflater.inflate(R.layout.fragment_search,container,false);
+      return view;
+   }
+}
+
+

--- a/BibBuddy/app/src/main/res/layout/activity_main.xml
+++ b/BibBuddy/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_main"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    android:layout_height="wrap_content"
+    tools:context="de.bibbuddy.MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <include
+        layout="@layout/navigation_bar"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/app_description"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_alignParentBottom="true" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>

--- a/BibBuddy/app/src/main/res/layout/fragment_home.xml
+++ b/BibBuddy/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_home"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="TODO Home" />
+
+</RelativeLayout>

--- a/BibBuddy/app/src/main/res/layout/fragment_library.xml
+++ b/BibBuddy/app/src/main/res/layout/fragment_library.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_library"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="TODO Bibliothek" />
+
+</RelativeLayout>

--- a/BibBuddy/app/src/main/res/layout/fragment_notes.xml
+++ b/BibBuddy/app/src/main/res/layout/fragment_notes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_notes"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="TODO Notizen" />
+
+</RelativeLayout>

--- a/BibBuddy/app/src/main/res/layout/fragment_search.xml
+++ b/BibBuddy/app/src/main/res/layout/fragment_search.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_search"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="TODO Suche" />
+
+</RelativeLayout>

--- a/BibBuddy/app/src/main/res/layout/navigation_bar.xml
+++ b/BibBuddy/app/src/main/res/layout/navigation_bar.xml
@@ -1,0 +1,13 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/navigation_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:labelVisibilityMode="labeled"
+        app:menu="@menu/navigation_menu" />
+
+</FrameLayout>

--- a/BibBuddy/app/src/main/res/menu/navigation_menu.xml
+++ b/BibBuddy/app/src/main/res/menu/navigation_menu.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/navigation_home"
+        android:icon="@android:drawable/ic_dialog_info"
+        android:title="@string/navigation_home" />
+    <item
+        android:id="@+id/navigation_search"
+        android:icon="@android:drawable/ic_search_category_default"
+        android:title="@string/navigation_search" />
+    <item
+        android:id="@+id/navigation_library"
+        android:icon="@android:drawable/ic_menu_gallery"
+        android:title="@string/navigation_library" />
+    <item
+        android:id="@+id/navigation_notes"
+        android:icon="@android:drawable/ic_menu_edit"
+        android:title="@string/navigation_notes" />
+
+</menu>

--- a/BibBuddy/app/src/main/res/values/strings.xml
+++ b/BibBuddy/app/src/main/res/values/strings.xml
@@ -1,4 +1,10 @@
 <resources>
     <string name="app_name">Bib Buddy</string>
-    <string name="app_description">Bib Buddy offers a platform for concentrated literary work. For that, we create an open atmosphere for your thoughts and ideas during research. Our service makes your literary work as intuitive as never before!</string>
+    <string name="app_description">Bib Buddy Home</string>
+
+    <!-- Navigation Bar -->
+    <string name="navigation_home">Home</string>
+    <string name="navigation_search">Suche</string>
+    <string name="navigation_library">Bibliothek</string>
+    <string name="navigation_notes">Notizen</string>
 </resources>


### PR DESCRIPTION
A navigation bar with four items Home, Suche, Bibliothek and Notizen is added. By clicking an item, a fragment with a sample text appears. The four fragments are HomeFragment, SearchFragment, LibraryFragment and NotesFragment which have their own corresponding layout XML file. @LuisMossburger please check if the basic navigation is okay. 