### PR TITLE
Manifest permission for device storage access

### DIFF
--- a/BibBuddy/app/src/main/AndroidManifest.xml
+++ b/BibBuddy/app/src/main/AndroidManifest.xml
@@ -4,13 +4,15 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-feature
         android:name="android.hardware.camera"
         android:required="true" />
-
+    
     <application
         android:allowBackup="true"
+        android:requestLegacyExternalStorage="true"
         android:icon="@drawable/bibbuddy_icon"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * The LibraryFragment is responsible for the shelves in the library.
  *
- * @author Claudia Schönherr,Silvia Ivanova
+ * @author Claudia Schönherr, Silvia Ivanova
  */
 public class LibraryFragment extends Fragment
     implements LibraryRecyclerViewAdapter.LibraryListener, BookRecyclerViewAdapter.BookListener {
@@ -78,7 +78,7 @@ public class LibraryFragment extends Fragment
   public boolean onOptionsItemSelected(MenuItem item) {
     switch (item.getItemId()) {
       case R.id.menu_backup_library:
-        handleBackupLibrary();
+        setStoragePermission();
         break;
 
       case R.id.menu_rename_shelf:
@@ -103,10 +103,6 @@ public class LibraryFragment extends Fragment
     return super.onOptionsItemSelected(item);
   }
 
-  private void handleBackupLibrary() {
-    setStoragePermission();
-  }
-
   private void setStoragePermission() {
     if (ContextCompat.checkSelfPermission(getContext(),
               Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
@@ -126,10 +122,10 @@ public class LibraryFragment extends Fragment
 
   private void showRequestPermissionDialog() {
     new AlertDialog.Builder(getContext())
-        .setTitle("Zugriff erforderlich")
-        .setMessage("Zugriff auf den Gerätespeicher erforderlich, "
-            + "um Dateien aus dieser App zu exportieren.")
-        .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+        .setTitle(R.string.storage_permission_needed)
+        .setMessage(R.string.storage_permission_alert_msg)
+
+        .setPositiveButton(R.string.storage_permission_ok_btn, new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {
             ActivityCompat.requestPermissions(getActivity(),
@@ -137,7 +133,8 @@ public class LibraryFragment extends Fragment
                 STORAGE_PERMISSION_CODE);
           }
         })
-        .setNegativeButton("Abbrechen", new DialogInterface.OnClickListener() {
+
+        .setNegativeButton(R.string.storage_permission_cancel_btn, new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {
             dialog.dismiss();
@@ -153,9 +150,9 @@ public class LibraryFragment extends Fragment
       case STORAGE_PERMISSION_CODE:
         if (grantResults.length <= 0
             || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-          Toast.makeText(context, "Zugriff verweigert", Toast.LENGTH_SHORT).show();
+          Toast.makeText(context, R.string.storage_permission_denied, Toast.LENGTH_SHORT).show();
         }
-        return;
+        break;
       default:
     }
   }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -126,22 +126,11 @@ public class LibraryFragment extends Fragment
         .setMessage(R.string.storage_permission_alert_msg)
 
         .setPositiveButton(R.string.storage_permission_ok_btn,
-            new DialogInterface.OnClickListener() {
-          @Override
-          public void onClick(DialogInterface dialog, int which) {
-            ActivityCompat.requestPermissions(getActivity(),
-                new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                STORAGE_PERMISSION_CODE);
-          }
-        })
+            (dialog, which) -> ActivityCompat.requestPermissions(getActivity(),
+                new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE}, STORAGE_PERMISSION_CODE))
 
         .setNegativeButton(R.string.storage_permission_cancel_btn,
-            new DialogInterface.OnClickListener() {
-          @Override
-          public void onClick(DialogInterface dialog, int which) {
-            dialog.dismiss();
-          }
-        })
+            (dialog, which) -> dialog.dismiss())
         .create().show();
   }
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -151,9 +151,8 @@ public class LibraryFragment extends Fragment
                                          String[] permissions, int[] grantResults) {
     switch (requestCode) {
       case STORAGE_PERMISSION_CODE:
-        if (grantResults.length > 0
-            && grantResults[0] == PackageManager.PERMISSION_GRANTED) { }
-        else {
+        if (grantResults.length <= 0
+            || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
           Toast.makeText(context, "Zugriff verweigert", Toast.LENGTH_SHORT).show();
         }
         return;

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -153,6 +153,7 @@ public class LibraryFragment extends Fragment
           Toast.makeText(context, R.string.storage_permission_denied, Toast.LENGTH_SHORT).show();
         }
         break;
+
       default:
     }
   }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -125,34 +125,35 @@ public class LibraryFragment extends Fragment
   }
 
   private void showRequestPermissionDialog() {
-      new AlertDialog.Builder (getContext())
-              .setTitle("Zugriff erforderlich")
-              .setMessage("Zugriff auf den Gerätespeicher erforderlich, " +
-                      "um Dateien aus dieser App zu exportieren.")
-              .setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                  @Override
-                  public void onClick(DialogInterface dialog, int which) {
-                      ActivityCompat.requestPermissions(getActivity(),
-                              new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                              STORAGE_PERMISSION_CODE);
-                    }
-                })
-                .setNegativeButton("Abbrechen", new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
+    new AlertDialog.Builder(getContext())
+        .setTitle("Zugriff erforderlich")
+        .setMessage("Zugriff auf den Gerätespeicher erforderlich, "
+            + "um Dateien aus dieser App zu exportieren.")
+        .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+          @Override
+          public void onClick(DialogInterface dialog, int which) {
+            ActivityCompat.requestPermissions(getActivity(),
+                new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                STORAGE_PERMISSION_CODE);
+          }
+        })
+        .setNegativeButton("Abbrechen", new DialogInterface.OnClickListener() {
+          @Override
+          public void onClick(DialogInterface dialog, int which) {
                         dialog.dismiss();
                     }
-                })
-                .create().show();
-    }
+        })
+        .create().show();
+  }
 
   @Override
-  public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+  public void onRequestPermissionsResult(int requestCode,
+                                         String[] permissions, int[] grantResults) {
     switch (requestCode) {
       case STORAGE_PERMISSION_CODE:
-        if(grantResults.length > 0 &&
-                grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-        } else {
+        if (grantResults.length > 0
+            && grantResults[0] == PackageManager.PERMISSION_GRANTED) {}
+        else {
           Toast.makeText(context, "Zugriff verweigert", Toast.LENGTH_SHORT).show();
         }
         return;
@@ -160,7 +161,7 @@ public class LibraryFragment extends Fragment
     }
   }
 
-    private void handleManualLibrary() {
+  private void handleManualLibrary() {
     HelpFragment helpFragment = new HelpFragment();
     String htmlAsString = getString(R.string.library_help_text);
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -140,8 +140,8 @@ public class LibraryFragment extends Fragment
         .setNegativeButton("Abbrechen", new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                    }
+            dialog.dismiss();
+          }
         })
         .create().show();
   }
@@ -152,7 +152,7 @@ public class LibraryFragment extends Fragment
     switch (requestCode) {
       case STORAGE_PERMISSION_CODE:
         if (grantResults.length > 0
-            && grantResults[0] == PackageManager.PERMISSION_GRANTED) {}
+            && grantResults[0] == PackageManager.PERMISSION_GRANTED) { }
         else {
           Toast.makeText(context, "Zugriff verweigert", Toast.LENGTH_SHORT).show();
         }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -1,8 +1,10 @@
 package de.bibbuddy;
 
+import android.Manifest;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -15,6 +17,8 @@ import android.widget.Toast;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -24,7 +28,7 @@ import java.util.List;
 /**
  * The LibraryFragment is responsible for the shelves in the library.
  *
- * @author Claudia Schönherr
+ * @author Claudia Schönherr,Silvia Ivanova
  */
 public class LibraryFragment extends Fragment
     implements LibraryRecyclerViewAdapter.LibraryListener, BookRecyclerViewAdapter.BookListener {
@@ -34,7 +38,7 @@ public class LibraryFragment extends Fragment
   private LibraryModel libraryModel;
   private LibraryRecyclerViewAdapter adapter;
   private List<ShelfItem> selectedShelfItems;
-
+  private static final int STORAGE_PERMISSION_CODE = 1;
 
   @Nullable
   @Override
@@ -75,9 +79,7 @@ public class LibraryFragment extends Fragment
 
     switch (item.getItemId()) {
       case R.id.menu_backup_library:
-        // TODO Silvia Export
-        // handleBackupLibrary();
-        Toast.makeText(getContext(), "Backup wurde geklickt", Toast.LENGTH_SHORT).show();
+        handleBackupLibrary();
         break;
 
       case R.id.menu_rename_shelf:
@@ -102,7 +104,59 @@ public class LibraryFragment extends Fragment
     return super.onOptionsItemSelected(item);
   }
 
-  private void handleManualLibrary() {
+  private void handleBackupLibrary() {
+      setStoragePermission();
+  }
+
+  private void setStoragePermission() {
+      if(ContextCompat.checkSelfPermission(getContext(),
+              Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+          requestStoragePermission();
+      }
+  }
+
+  private void requestStoragePermission() {
+      if(ActivityCompat.shouldShowRequestPermissionRationale(getActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+          showRequestPermissionDialog();
+      } else {
+          requestPermissions(new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE}, STORAGE_PERMISSION_CODE);
+      }
+  }
+
+  private void showRequestPermissionDialog() {
+      new AlertDialog.Builder (getContext())
+              .setTitle("Zugriff erforderlich")
+              .setMessage("Zugriff auf den Gerätespeicher erforderlich, um Dateien aus dieser App zu exportieren.")
+              .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                  @Override
+                  public void onClick(DialogInterface dialog, int which) {
+                      ActivityCompat.requestPermissions(getActivity(),
+                              new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE}, STORAGE_PERMISSION_CODE);
+                    }
+                })
+                .setNegativeButton("Abbrechen", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.dismiss();
+                    }
+                })
+                .create().show();
+    }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+      switch (requestCode) {
+          case STORAGE_PERMISSION_CODE:
+              if(grantResults.length > 0 &&
+                      grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+              } else {
+                  Toast.makeText(context, "Zugriff verweigert", Toast.LENGTH_SHORT).show();
+              }
+              return;
+      }
+  }
+
+    private void handleManualLibrary() {
     HelpFragment helpFragment = new HelpFragment();
     String htmlAsString = getString(R.string.library_help_text);
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -125,7 +125,8 @@ public class LibraryFragment extends Fragment
         .setTitle(R.string.storage_permission_needed)
         .setMessage(R.string.storage_permission_alert_msg)
 
-        .setPositiveButton(R.string.storage_permission_ok_btn, new DialogInterface.OnClickListener() {
+        .setPositiveButton(R.string.storage_permission_ok_btn,
+            new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {
             ActivityCompat.requestPermissions(getActivity(),
@@ -134,7 +135,8 @@ public class LibraryFragment extends Fragment
           }
         })
 
-        .setNegativeButton(R.string.storage_permission_cancel_btn, new DialogInterface.OnClickListener() {
+        .setNegativeButton(R.string.storage_permission_cancel_btn,
+            new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {
             dialog.dismiss();

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -76,7 +76,6 @@ public class LibraryFragment extends Fragment
 
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
-
     switch (item.getItemId()) {
       case R.id.menu_backup_library:
         handleBackupLibrary();
@@ -105,33 +104,37 @@ public class LibraryFragment extends Fragment
   }
 
   private void handleBackupLibrary() {
-      setStoragePermission();
+    setStoragePermission();
   }
 
   private void setStoragePermission() {
-      if(ContextCompat.checkSelfPermission(getContext(),
+    if (ContextCompat.checkSelfPermission(getContext(),
               Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-          requestStoragePermission();
-      }
+      requestStoragePermission();
+    }
   }
 
   private void requestStoragePermission() {
-      if(ActivityCompat.shouldShowRequestPermissionRationale(getActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-          showRequestPermissionDialog();
-      } else {
-          requestPermissions(new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE}, STORAGE_PERMISSION_CODE);
-      }
+    if (ActivityCompat.shouldShowRequestPermissionRationale(getActivity(),
+            Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+      showRequestPermissionDialog();
+    } else {
+      requestPermissions(new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
+              STORAGE_PERMISSION_CODE);
+    }
   }
 
   private void showRequestPermissionDialog() {
       new AlertDialog.Builder (getContext())
               .setTitle("Zugriff erforderlich")
-              .setMessage("Zugriff auf den Gerätespeicher erforderlich, um Dateien aus dieser App zu exportieren.")
+              .setMessage("Zugriff auf den Gerätespeicher erforderlich, " +
+                      "um Dateien aus dieser App zu exportieren.")
               .setPositiveButton("OK", new DialogInterface.OnClickListener() {
                   @Override
                   public void onClick(DialogInterface dialog, int which) {
                       ActivityCompat.requestPermissions(getActivity(),
-                              new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE}, STORAGE_PERMISSION_CODE);
+                              new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                              STORAGE_PERMISSION_CODE);
                     }
                 })
                 .setNegativeButton("Abbrechen", new DialogInterface.OnClickListener() {
@@ -145,15 +148,16 @@ public class LibraryFragment extends Fragment
 
   @Override
   public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-      switch (requestCode) {
-          case STORAGE_PERMISSION_CODE:
-              if(grantResults.length > 0 &&
-                      grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-              } else {
-                  Toast.makeText(context, "Zugriff verweigert", Toast.LENGTH_SHORT).show();
-              }
-              return;
-      }
+    switch (requestCode) {
+      case STORAGE_PERMISSION_CODE:
+        if(grantResults.length > 0 &&
+                grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        } else {
+          Toast.makeText(context, "Zugriff verweigert", Toast.LENGTH_SHORT).show();
+        }
+        return;
+      default:
+    }
   }
 
     private void handleManualLibrary() {

--- a/BibBuddy/app/src/main/res/values/strings.xml
+++ b/BibBuddy/app/src/main/res/values/strings.xml
@@ -140,7 +140,10 @@
 
     <!-- Export Dialog Alert Window Descriptions -->
     <string name="storage_permission_needed">Zugriff erforderlich</string>
-    <string name="storage_permission_alert_msg">Zugriff auf den Gerätespeicher erforderlich, um Dateien aus dieser App zu exportieren.</string>
+    <string name="storage_permission_alert_msg">
+        Zugriff auf den Gerätespeicher erforderlich,
+        um Dateien aus dieser App zu exportieren.
+    </string>
     <string name="storage_permission_ok_btn">OK</string>
     <string name="storage_permission_cancel_btn">Abbrechen</string>
     <string name="storage_permission_denied">Zugriff verweigert</string>

--- a/BibBuddy/app/src/main/res/values/strings.xml
+++ b/BibBuddy/app/src/main/res/values/strings.xml
@@ -137,6 +137,14 @@
     <string name="format_options">Format Options</string>
     <string name="format_arrow">Format Arrow</string>
 
+
+    <!-- Export Dialog Alert Window Descriptions -->
+    <string name="storage_permission_needed">Zugriff erforderlich</string>
+    <string name="storage_permission_alert_msg">Zugriff auf den Gerätespeicher erforderlich, um Dateien aus dieser App zu exportieren.</string>
+    <string name="storage_permission_ok_btn">OK</string>
+    <string name="storage_permission_cancel_btn">Abbrechen</string>
+    <string name="storage_permission_denied">Zugriff verweigert</string>
+
     <!-- Help Fragment -->
     <string name="headerHelp">Hilfe</string>
 
@@ -322,6 +330,11 @@
         exportiert.</p>
         ]]>
     </string>
+
+
+
+
+    ""
 
 
 </resources>


### PR DESCRIPTION
### Description
Added permission requests and set up Manifest permissions for storage access of the current device..

### Affects
@claudia3 

### Notes for Reviewer

1. Create and then select one/ more shelves from the library ("Bibliothek"-Fragment).
2. Then select the "Backup"-option from the menu on the top right corner.
3. A dialog window with different options (allow, deny etc.) should be displayed.
![image](https://user-images.githubusercontent.com/37459401/109032984-7d234e00-76c6-11eb-8fc3-1d6e30ed14fd.png)

- If you select "Allow", then check if your device has access to your storage.

- If you select "Deny", a window with further information should be shown:
![image](https://user-images.githubusercontent.com/37459401/109033140-9e843a00-76c6-11eb-82a2-c6c0df4de50e.png)

- If you select "Deny & don't ask again"-option and after that try to backup the data, then a message will be shown.
![image](https://user-images.githubusercontent.com/37459401/109032655-29b10000-76c6-11eb-8312-ba70e32bd5e5.png)

Check if it works. 
Please review & comment/approve.
