### PR TITLE
Export an example .bib file to device storage

### DIFF
--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.os.Environment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -22,6 +24,12 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -79,6 +87,11 @@ public class LibraryFragment extends Fragment
     switch (item.getItemId()) {
       case R.id.menu_backup_library:
         setStoragePermission();
+
+        //use the same parameter in order to be able to write
+        //in a specific file that already exists
+        createBibFile("Download", "exampleBibFilename");
+        writeBibFile("Download", "exampleBibFilename");
         break;
 
       case R.id.menu_rename_shelf:
@@ -146,6 +159,64 @@ public class LibraryFragment extends Fragment
         break;
 
       default:
+    }
+  }
+
+  private void createBibFile(String folderName, String fileName) {
+    try {
+      String rootPath = Environment.getExternalStorageDirectory()
+          .getAbsolutePath() + "/" + folderName + "/";
+      File root = new File(rootPath);
+
+      if (!root.exists()) {
+        root.mkdirs();
+      }
+
+      File file = new File(rootPath + fileName + ".bib");
+      if (file.exists()) {
+        file.delete();
+      }
+      file.createNewFile();
+
+      FileOutputStream out = new FileOutputStream(file);
+      out.flush();
+      out.close();
+
+      Toast.makeText(context, "File exported in: " + '\n'
+          + rootPath + fileName + ".bib", Toast.LENGTH_LONG).show();
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void writeBibFile(String folderName, String fileName) {
+    try {
+      File dir = new File(Environment.getExternalStorageDirectory()
+          .getAbsolutePath() + "/" + folderName + "/");
+
+      if (!dir.exists()) {
+        dir.mkdirs();
+      }
+
+      File statText = new File(Environment.getExternalStorageDirectory()
+          + "/" + folderName + "/" + fileName + ".bib");
+
+      FileOutputStream fos = new FileOutputStream(statText);
+      OutputStreamWriter osw = new OutputStreamWriter(fos);
+      Writer fileWriter = new BufferedWriter(osw);
+
+      fileWriter.write("@book{hawking1988," + '\n'
+          + "title        = {The impossible book}," + '\n'
+          + "author       = {Stefa{n} Sweig}," + '\n'
+          +  "year         = 1942," + '\n'
+          + "publisher    = {Dead Poet Society}" + '\n'
+          + "note         = some note example" + '\n' + "}" + '\n'
+      );
+      fileWriter.close();
+
+    } catch (IOException e) {
+      Log.e("Exception", R.string.file_write_failed + e.toString());
     }
   }
 

--- a/BibBuddy/app/src/main/res/values/strings.xml
+++ b/BibBuddy/app/src/main/res/values/strings.xml
@@ -147,6 +147,7 @@
     <string name="storage_permission_ok_btn">OK</string>
     <string name="storage_permission_cancel_btn">Abbrechen</string>
     <string name="storage_permission_denied">Zugriff verweigert</string>
+    <string name="file_write_failed">File write failed:</string>
 
     <!-- Help Fragment -->
     <string name="headerHelp">Hilfe</string>


### PR DESCRIPTION
### Description
Added methods for export an example .bib file to device storage.

### Affects
Library-fragment

### Notes for Reviewer

1. Create and then select one/ more shelves from the library ("Bibliothek"-Fragment).
2. Then select the "Backup"-option from the menu on the top right corner.
3. An example .bib file is saved to your device storage.
![image](https://user-images.githubusercontent.com/37459401/109068185-cb007c00-76ef-11eb-9b04-3faa7e4bc2bb.png)

- Convert the stored .bib file to citation here:
[https://balanceofcowards.net/bibtex2pdf.html](url)

Note: you need to allow the permissions for accessing the device storage.
Please review & comment/approve.