### PR TITLE
Implement author API

### DIFF
--- a/BibBuddy/app/src/main/java/de/bibbuddy/AuthorRetriever.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/AuthorRetriever.java
@@ -1,0 +1,95 @@
+package de.bibbuddy;
+
+import java.io.StringReader;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+
+/**
+ * The IsbnRetriever class connects to the API and returns metadata for an ISBN.
+ *
+ * @author Luis Moßburger
+ */
+public class AuthorRetriever {
+
+  private final String autApiUrl = "https://d-nb.info/gnd/";
+  private final String autApiParam = "/about/marcxml";
+
+  private static Document loadXmlFromString(String xml) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    InputSource is = new InputSource(new StringReader(xml));
+
+    return builder.parse(is);
+  }
+
+  public void extractAuthors(NodeList authors) {
+    String url;
+    Element autEl;
+    Thread thread;
+    ApiReader apiReader;
+    Document xmlMetadata = null;
+
+    System.out.println("autoren aufgerufen");
+
+    if (authors.getLength() > 0) {
+      for (int i = 0; i < authors.getLength(); i++) {
+
+        // read from API with isbn (Thread)
+        autEl = (Element) authors.item(i);
+        url = autEl.getAttribute("rdf:resource");
+        apiReader = new ApiReader(this.autApiUrl + url.split("/gnd/")[1] + this.autApiParam);
+        thread = new Thread(apiReader);
+        thread.start();
+
+        try {
+          thread.join();
+        } catch (Exception e) {
+          System.out.println(e);
+        }
+
+        // retrieve metadata that was saved
+        String metadata = apiReader.getMetadata();
+        if (metadata != null) {
+          // parse xml
+          try {
+            System.out.println(metadata);
+            xmlMetadata = loadXmlFromString(metadata);
+            extractAuthorName(xmlMetadata);
+          } catch (Exception e) {
+            System.out.println(e);
+          }
+        }
+      }
+    }
+  }
+
+  private String extractAuthorName(Document xmlMetadata) {
+    String authorName = "";
+    XPath xpath = XPathFactory.newInstance().newXPath();
+
+    try {
+      // in MARCXML, datafield "100" (suggested name for the person) is only present once
+      // (cataloguing rules for libraries)
+      XPathExpression expr = xpath.compile("//datafield[@tag=\"100\"]//subfield[@code=\"a\"]");
+      Object exprResult = expr.evaluate(xmlMetadata, XPathConstants.NODESET);
+      NodeList authorNameWrapper = (NodeList) exprResult;
+      String aut = authorNameWrapper.item(0).getTextContent();
+      authorName = aut;
+    } catch (Exception e) {
+      System.out.println(e);
+    }
+
+    return authorName;
+  }
+
+}

--- a/BibBuddy/app/src/main/java/de/bibbuddy/AuthorRetriever.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/AuthorRetriever.java
@@ -28,9 +28,9 @@ public class AuthorRetriever {
   private static Document loadXmlFromString(String xml) throws Exception {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = factory.newDocumentBuilder();
-    InputSource is = new InputSource(new StringReader(xml));
+    InputSource inputSource = new InputSource(new StringReader(xml));
 
-    return builder.parse(is);
+    return builder.parse(inputSource);
   }
 
   /**
@@ -114,7 +114,7 @@ public class AuthorRetriever {
       NodeList authorNameWrapper = (NodeList) exprResult;
       String authorName = authorNameWrapper.item(0).getTextContent();
       // MARCXML datafield "100" subfield code "a" is always in this form: Lastname, First Name
-      author = new Author(authorName.split(",")[1], authorName.split(",")[0]);
+      author = new Author(authorName.split(",")[1].trim(), authorName.split(",")[0].trim());
     } catch (Exception e) {
       System.out.println(e);
     }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/AuthorRetriever.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/AuthorRetriever.java
@@ -1,6 +1,8 @@
 package de.bibbuddy;
 
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
@@ -32,14 +34,14 @@ public class AuthorRetriever {
     return builder.parse(is);
   }
 
-  public void extractAuthors(NodeList authors) {
+  public List<Author> extractAuthors(NodeList authors) {
     String url;
     Element autEl;
+    List<Author> authorArray = new ArrayList<Author>();
+
     Thread thread;
     ApiReader apiReader;
     Document xmlMetadata = null;
-
-    System.out.println("autoren aufgerufen");
 
     if (authors.getLength() > 0) {
       for (int i = 0; i < authors.getLength(); i++) {
@@ -62,19 +64,20 @@ public class AuthorRetriever {
         if (metadata != null) {
           // parse xml
           try {
-            System.out.println(metadata);
             xmlMetadata = loadXmlFromString(metadata);
-            extractAuthorName(xmlMetadata);
+            authorArray.add(constructAuthor(xmlMetadata));
           } catch (Exception e) {
             System.out.println(e);
           }
         }
       }
     }
+
+    return authorArray;
   }
 
-  private String extractAuthorName(Document xmlMetadata) {
-    String authorName = "";
+  private Author constructAuthor(Document xmlMetadata) {
+    Author author = null;
     XPath xpath = XPathFactory.newInstance().newXPath();
 
     try {
@@ -83,13 +86,14 @@ public class AuthorRetriever {
       XPathExpression expr = xpath.compile("//datafield[@tag=\"100\"]//subfield[@code=\"a\"]");
       Object exprResult = expr.evaluate(xmlMetadata, XPathConstants.NODESET);
       NodeList authorNameWrapper = (NodeList) exprResult;
-      String aut = authorNameWrapper.item(0).getTextContent();
-      authorName = aut;
+      String authorName = authorNameWrapper.item(0).getTextContent();
+      // MARCXML datafield "100" subfield code "a" is always in this form: Lastname, First Name
+      author = new Author(authorName.split(",")[1], authorName.split(",")[0]);
     } catch (Exception e) {
       System.out.println(e);
     }
 
-    return authorName;
+    return author;
   }
 
 }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/BookBarcodeScannerFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/BookBarcodeScannerFragment.java
@@ -160,7 +160,6 @@ public class BookBarcodeScannerFragment extends Fragment {
   }
 
   private void handleAddBook(Book book, List<Author> authors) {
-    // TODO authors of a book
     BookDao bookDao = new BookDao(new DatabaseHelper(getContext()));
     bookDao.create(book, authors, shelfId);
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/BookBarcodeScannerFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/BookBarcodeScannerFragment.java
@@ -22,6 +22,7 @@ import com.google.android.gms.vision.barcode.Barcode;
 import com.google.android.gms.vision.barcode.BarcodeDetector;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The BookBarcodeScannerFragment is responsible to scan the ISBN of the book
@@ -143,9 +144,10 @@ public class BookBarcodeScannerFragment extends Fragment {
 
     // retrieve metadata that was saved
     Book book = isbnRetriever.getBook();
+    List<Author> authors = isbnRetriever.getAuthors();
     closeFragment();
     if (book != null) {
-      handleAddBook(book);
+      handleAddBook(book, authors);
     } else {
       
       getActivity().runOnUiThread(new Runnable() {
@@ -157,10 +159,10 @@ public class BookBarcodeScannerFragment extends Fragment {
     }
   }
 
-  private void handleAddBook(Book book) {
+  private void handleAddBook(Book book, List<Author> authors) {
     // TODO authors of a book
     BookDao bookDao = new BookDao(new DatabaseHelper(getContext()));
-    bookDao.create(book, new ArrayList<Author>(), shelfId);
+    bookDao.create(book, authors, shelfId);
 
     getActivity().runOnUiThread(new Runnable() {
       public void run() {

--- a/BibBuddy/app/src/main/java/de/bibbuddy/BookOnlineFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/BookOnlineFragment.java
@@ -14,6 +14,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import com.google.android.material.textfield.TextInputLayout;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The BookOnlineFragment is responsible for the online search of books.
@@ -103,8 +104,9 @@ public class BookOnlineFragment extends Fragment {
 
         // retrieve metadata that was saved
         Book book = isbnRetriever.getBook();
+        List<Author> authors = isbnRetriever.getAuthors();
         if (book != null) {
-          handleAddBook(book);
+          handleAddBook(book, authors);
         } else {
           Toast.makeText(getActivity(), getString(R.string.isbn_not_found),
               Toast.LENGTH_LONG).show();
@@ -113,14 +115,17 @@ public class BookOnlineFragment extends Fragment {
     }
   }
 
-  private void handleAddBook(Book book) {
-    Toast.makeText(getActivity(), getString(R.string.added_book),
-                   Toast.LENGTH_LONG).show();
+  private void handleAddBook(Book book, List<Author> authors) {
+    try {
+      BookDao bookDao = new BookDao(new DatabaseHelper(getContext()));
+      bookDao.create(book, authors, shelfId);
 
-    // TODO authors of a book
-    BookDao bookDao = new BookDao(new DatabaseHelper(getContext()));
-    bookDao.create(book, new ArrayList<Author>(), shelfId);
+      Toast.makeText(getActivity(), getString(R.string.added_book),
+          Toast.LENGTH_LONG).show();
 
-    closeFragment();
+      closeFragment();
+    } catch (Exception e) {
+      System.out.println(e);
+    }
   }
 }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/IsbnRetriever.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/IsbnRetriever.java
@@ -12,6 +12,7 @@ public class IsbnRetriever implements Runnable {
   private final String apiUrl = "https://lod.b3kat.de/";
   private final String apiXmlParameter = "?output=xml";
   private final String isbnApi = apiUrl + "data/isbn/%s" + apiXmlParameter;
+
   private final String isbn;
   private Book book = null;
 
@@ -45,6 +46,16 @@ public class IsbnRetriever implements Runnable {
         "", // volume
         "", // edition
         ""); // addInfos
+  }
+
+  private void createAuthors(Document xmlMetadata) {
+    AuthorRetriever authorRetriever = new AuthorRetriever();
+    System.out.println("autoren aufrufen");
+    if (xmlMetadata.getElementsByTagName("marcrel:aut").getLength() > 0) {
+      authorRetriever.extractAuthors(xmlMetadata.getElementsByTagName("marcrel:aut"));
+    } else {
+      authorRetriever.extractAuthors(xmlMetadata.getElementsByTagName("dcterms:contributor"));
+    }
   }
 
   /**
@@ -105,7 +116,8 @@ public class IsbnRetriever implements Runnable {
           System.out.println(e);
         }
 
-        // create a record
+        // create record & authors
+        createAuthors(xmlMetadata);
         book = createRecord(xmlMetadata);
       }
     }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/IsbnRetriever.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/IsbnRetriever.java
@@ -54,13 +54,7 @@ public class IsbnRetriever implements Runnable {
   private List<Author> createAuthors(Document xmlMetadata) {
     List<Author> authors = new ArrayList<Author>();
     AuthorRetriever authorRetriever = new AuthorRetriever();
-
-    if (xmlMetadata.getElementsByTagName("marcrel:aut").getLength() > 0) {
-      authors = authorRetriever.extractAuthors(xmlMetadata.getElementsByTagName("marcrel:aut"));
-    } else {
-      authors = authorRetriever.extractAuthors(xmlMetadata.getElementsByTagName("dcterms:contributor"));
-    }
-
+    authors = authorRetriever.extractAuthors(xmlMetadata);
     return authors;
   }
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/IsbnRetriever.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/IsbnRetriever.java
@@ -32,9 +32,9 @@ public class IsbnRetriever implements Runnable {
   private static Document loadXmlFromString(String xml) throws Exception {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = factory.newDocumentBuilder();
-    InputSource is = new InputSource(new StringReader(xml));
+    InputSource inputSource = new InputSource(new StringReader(xml));
 
-    return builder.parse(is);
+    return builder.parse(inputSource);
   }
 
   private Book createRecord(Document xmlMetadata) {

--- a/BibBuddy/app/src/main/java/de/bibbuddy/IsbnRetriever.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/IsbnRetriever.java
@@ -1,6 +1,8 @@
 package de.bibbuddy;
 
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.w3c.dom.Document;
@@ -15,6 +17,7 @@ public class IsbnRetriever implements Runnable {
 
   private final String isbn;
   private Book book = null;
+  private List<Author> authors = new ArrayList<Author>();
 
   /**
    * The IsbnRetriever class connects to the API and returns metadata for an ISBN.
@@ -48,14 +51,17 @@ public class IsbnRetriever implements Runnable {
         ""); // addInfos
   }
 
-  private void createAuthors(Document xmlMetadata) {
+  private List<Author> createAuthors(Document xmlMetadata) {
+    List<Author> authors = new ArrayList<Author>();
     AuthorRetriever authorRetriever = new AuthorRetriever();
-    System.out.println("autoren aufrufen");
+
     if (xmlMetadata.getElementsByTagName("marcrel:aut").getLength() > 0) {
-      authorRetriever.extractAuthors(xmlMetadata.getElementsByTagName("marcrel:aut"));
+      authors = authorRetriever.extractAuthors(xmlMetadata.getElementsByTagName("marcrel:aut"));
     } else {
-      authorRetriever.extractAuthors(xmlMetadata.getElementsByTagName("dcterms:contributor"));
+      authors = authorRetriever.extractAuthors(xmlMetadata.getElementsByTagName("dcterms:contributor"));
     }
+
+    return authors;
   }
 
   /**
@@ -117,7 +123,7 @@ public class IsbnRetriever implements Runnable {
         }
 
         // create record & authors
-        createAuthors(xmlMetadata);
+        authors = createAuthors(xmlMetadata);
         book = createRecord(xmlMetadata);
       }
     }
@@ -125,6 +131,10 @@ public class IsbnRetriever implements Runnable {
 
   public Book getBook() {
     return book;
+  }
+
+  public List<Author> getAuthors() {
+    return authors;
   }
 
 }


### PR DESCRIPTION
**Description**
Closes #90. Authors have to be received with a second API. This is now automatically done when scanning an ISBN and the authors saved in the database.

**Affects**
New class, slightly barcode scanning and online search.

**Notes for Reviewer**
Maybe try with some ISBNs (examples below, as our API obviously does not have all of them). Thanks!
Please review & comment/approve.

Available: https://barcode.tec-it.com/de/ISBN13?data=340734211X
Available: https://barcode.tec-it.com/de/ISBN13?data=9781234567897
Not available: https://barcode.tec-it.com/de/ISBN13?data=978-3-030-02111-5