### PR TITLE
Bugfix note text without formatting tags

### DIFF
--- a/BibBuddy/app/src/main/java/de/bibbuddy/ExportBibTex.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/ExportBibTex.java
@@ -29,7 +29,7 @@ public class ExportBibTex {
    *
    * @param folderName name of the folder in which the
    *                   BibTex file should be stored
-   * @param fileName name of the BibTex file
+   * @param fileName   name of the BibTex file
    */
   public ExportBibTex(String folderName, String fileName) {
     this.folderName = folderName;
@@ -68,14 +68,14 @@ public class ExportBibTex {
    * notes from the entire library.
    *
    * @param libraryModel object of the LibraryModel class
-   * @param bookDao object of the class BookDao
-   *                Depends on the used fragment.
-   *                Can be accessed through BookModel, LibraryModel
-   *                or BookNotesViewModel.
-   * @param noteDao object of the class NoteDao
-   *                Depends on the used fragment.
-   *                Can be accessed through BookModel, LibraryModel
-   *                or BookNotesViewModel.
+   * @param bookDao      object of the class BookDao
+   *                     Depends on the used fragment.
+   *                     Can be accessed through BookModel, LibraryModel
+   *                     or BookNotesViewModel.
+   * @param noteDao      object of the class NoteDao
+   *                     Depends on the used fragment.
+   *                     Can be accessed through BookModel, LibraryModel
+   *                     or BookNotesViewModel.
    * @return the BibTex format of a library as String
    */
   public String getBibDataLibrary(LibraryModel libraryModel,
@@ -129,7 +129,7 @@ public class ExportBibTex {
   /**
    * Generates the BibTex format for a given book.
    *
-   * @param bookId id of the book
+   * @param bookId  id of the book
    * @param bookDao object of the class BookDao
    *                Depends on the used fragment.
    *                Can be accessed through BookModel, LibraryModel
@@ -143,29 +143,29 @@ public class ExportBibTex {
   public String getBibDataFromBook(Long bookId, BookDao bookDao, NoteDao noteDao) {
     Book book = bookDao.findById(bookId);
 
-    return  BibTexKeys.BOOK_TAG + BibTexKeys.OPENING_CURLY_BRACKET + getBibKey(book)
+    return BibTexKeys.BOOK_TAG + BibTexKeys.OPENING_CURLY_BRACKET + getBibKey(book)
 
-            + BibTexKeys.ISBN + BibTexKeys.OPENING_CURLY_BRACKET + book.getIsbn()
-            + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
+        + BibTexKeys.ISBN + BibTexKeys.OPENING_CURLY_BRACKET + book.getIsbn()
+        + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
 
-            + getBibAuthorNames(bookId, bookDao)
+        + getBibAuthorNames(bookId, bookDao)
 
-            + BibTexKeys.BOOK_TITLE + BibTexKeys.OPENING_CURLY_BRACKET + book.getTitle()
-            + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
+        + BibTexKeys.BOOK_TITLE + BibTexKeys.OPENING_CURLY_BRACKET + book.getTitle()
+        + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
 
-            + BibTexKeys.SUBTITLE + BibTexKeys.OPENING_CURLY_BRACKET + book.getSubtitle()
-            + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
+        + BibTexKeys.SUBTITLE + BibTexKeys.OPENING_CURLY_BRACKET + book.getSubtitle()
+        + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
 
-            + BibTexKeys.PUBLISHER + BibTexKeys.OPENING_CURLY_BRACKET + book.getPublisher()
-            + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
+        + BibTexKeys.PUBLISHER + BibTexKeys.OPENING_CURLY_BRACKET + book.getPublisher()
+        + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
 
-            + BibTexKeys.EDITION + BibTexKeys.OPENING_CURLY_BRACKET + book.getEdition()
-            + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
+        + BibTexKeys.EDITION + BibTexKeys.OPENING_CURLY_BRACKET + book.getEdition()
+        + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + '\n'
 
-            + getBibNotesFromBook(book, noteDao)
+        + getBibNotesFromBook(book, noteDao)
 
-            + BibTexKeys.YEAR + book.getPubYear() + '\n' + BibTexKeys.CLOSING_CURLY_BRACKET
-            + '\n' + '\n';
+        + BibTexKeys.YEAR + book.getPubYear() + '\n' + BibTexKeys.CLOSING_CURLY_BRACKET
+        + '\n' + '\n';
 
   }
 
@@ -222,8 +222,8 @@ public class ExportBibTex {
           + File.separator + folderName + File.separator + fileName
           + StorageKeys.BIB_FILE_TYPE);
 
-      FileOutputStream fileOutputStream  = new FileOutputStream(bibFile);
-      OutputStreamWriter outputStreamWriter  = new OutputStreamWriter(fileOutputStream);
+      FileOutputStream fileOutputStream = new FileOutputStream(bibFile);
+      OutputStreamWriter outputStreamWriter = new OutputStreamWriter(fileOutputStream);
       Writer fileWriter = new BufferedWriter(outputStreamWriter);
       fileWriter.write(bibContent);
       fileWriter.close();

--- a/BibBuddy/app/src/main/java/de/bibbuddy/ExportBibTex.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/ExportBibTex.java
@@ -14,7 +14,7 @@ import java.util.List;
  * It contains methods for generation of contents that are
  * used for the export of the BibTex file.
  *
- * @author Silvia Ivanova
+ * @author Silvia Ivanova, Luis Moßburger
  */
 
 public class ExportBibTex {
@@ -180,7 +180,7 @@ public class ExportBibTex {
 
     if (!notesList.isEmpty()) {
       for (int k = 0; k < notesList.size(); k++) {
-        String bookTextNotes = noteDao.findTextById(notesList.get(k));
+        String bookTextNotes = noteDao.findStrippedTextById(notesList.get(k));
         allNotes.append(bookTextNotes);
       }
     }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
@@ -31,7 +31,7 @@ public class NoteDao implements InterfaceNoteDao {
         db.insert(DatabaseHelper.TABLE_NAME_NOTE_FILE, null, noteFile);
         Cursor c =
             db.query(DatabaseHelper.TABLE_NAME_NOTE_FILE, null, null,
-                     null, null, null, null);
+                null, null, null, null);
         c.moveToLast();
 
         ContentValues contentValues = new ContentValues();
@@ -47,7 +47,7 @@ public class NoteDao implements InterfaceNoteDao {
 
         Cursor cursor =
             db.query(DatabaseHelper.TABLE_NAME_NOTE, null, null, null,
-                     null, null, null);
+                null, null, null);
         cursor.moveToLast();
         long id = cursor.getLong(0);
         cursor.close();
@@ -69,12 +69,12 @@ public class NoteDao implements InterfaceNoteDao {
     SQLiteDatabase db = dbHelper.getReadableDatabase();
 
     Cursor cursor = db.query(DatabaseHelper.TABLE_NAME_NOTE,
-                             new String[] {DatabaseHelper._ID, DatabaseHelper.NAME,
-                                 DatabaseHelper.TYPE, DatabaseHelper.TEXT,
-                                 DatabaseHelper.CREATE_DATE, DatabaseHelper.MOD_DATE,
-                                 DatabaseHelper.NOTE_FILE_ID},
-                             DatabaseHelper._ID + "=?", new String[] {String.valueOf(id)},
-                             null, null, null, String.valueOf(1));
+        new String[] {DatabaseHelper._ID, DatabaseHelper.NAME,
+            DatabaseHelper.TYPE, DatabaseHelper.TEXT,
+            DatabaseHelper.CREATE_DATE, DatabaseHelper.MOD_DATE,
+            DatabaseHelper.NOTE_FILE_ID},
+        DatabaseHelper._ID + "=?", new String[] {String.valueOf(id)},
+        null, null, null, String.valueOf(1));
 
     Note note = null;
     if (cursor.moveToFirst()) {
@@ -116,10 +116,10 @@ public class NoteDao implements InterfaceNoteDao {
   public void delete(Long id) {
     SQLiteDatabase db = dbHelper.getWritableDatabase();
     db.delete(DatabaseHelper.TABLE_NAME_NOTE, DatabaseHelper._ID + " = ?",
-              new String[] {String.valueOf(id)});
+        new String[] {String.valueOf(id)});
 
     db.delete(DatabaseHelper.TABLE_NAME_BOOK_NOTE_LNK, DatabaseHelper.NOTE_ID + " = ?",
-              new String[] {String.valueOf(id)});
+        new String[] {String.valueOf(id)});
 
     db.close();
   }
@@ -140,8 +140,8 @@ public class NoteDao implements InterfaceNoteDao {
     values.put("text", text);
     values.put("modifikation_date", currentTime);
     dbHelper.getWritableDatabase().update(DatabaseHelper.TABLE_NAME_NOTE, values,
-                                          DatabaseHelper._ID + " = ?",
-                                          new String[] {String.valueOf(id)});
+        DatabaseHelper._ID + " = ?",
+        new String[] {String.valueOf(id)});
     SQLiteDatabase db = dbHelper.getWritableDatabase();
     db.close();
   }
@@ -223,12 +223,12 @@ public class NoteDao implements InterfaceNoteDao {
     SQLiteDatabase db = dbHelper.getReadableDatabase();
 
     Cursor cursor = db.query(DatabaseHelper.TABLE_NAME_NOTE,
-                             new String[] {DatabaseHelper._ID, DatabaseHelper.NAME,
-                                 DatabaseHelper.TYPE, DatabaseHelper.TEXT,
-                                 DatabaseHelper.CREATE_DATE, DatabaseHelper.MOD_DATE,
-                                 DatabaseHelper.NOTE_FILE_ID},
-                             DatabaseHelper._ID + "=?", new String[] {String.valueOf(id)},
-                             null, null, null, String.valueOf(1));
+        new String[] {DatabaseHelper._ID, DatabaseHelper.NAME,
+            DatabaseHelper.TYPE, DatabaseHelper.TEXT,
+            DatabaseHelper.CREATE_DATE, DatabaseHelper.MOD_DATE,
+            DatabaseHelper.NOTE_FILE_ID},
+        DatabaseHelper._ID + "=?", new String[] {String.valueOf(id)},
+        null, null, null, String.valueOf(1));
 
     String noteText = null;
     if (cursor.moveToFirst()) {
@@ -244,27 +244,10 @@ public class NoteDao implements InterfaceNoteDao {
    * This method gets text string of a specific note without formatting xml tags.
    *
    * @param id id of the note to look for
-   * @return returns the notes text value
+   * @return returns the notes text value without formatting texts
    */
   public String findStrippedTextById(Long id) {
-    SQLiteDatabase db = dbHelper.getReadableDatabase();
-
-    Cursor cursor = db.query(DatabaseHelper.TABLE_NAME_NOTE,
-        new String[] {DatabaseHelper._ID, DatabaseHelper.NAME,
-            DatabaseHelper.TYPE, DatabaseHelper.TEXT,
-            DatabaseHelper.CREATE_DATE, DatabaseHelper.MOD_DATE,
-            DatabaseHelper.NOTE_FILE_ID},
-        DatabaseHelper._ID + "=?", new String[] {String.valueOf(id)},
-        null, null, null, String.valueOf(1));
-
-    String noteText = null;
-    if (cursor.moveToFirst()) {
-      noteText = cursor.getString(3);
-    }
-
-    cursor.close();
-
-    return noteText.replaceAll("<[^>]+>", "");
+    return findTextById(id).replaceAll("<[^>]+>", "");
   }
 
   private Note createNoteData(Cursor cursor) {
@@ -319,10 +302,10 @@ public class NoteDao implements InterfaceNoteDao {
     SQLiteDatabase db = dbHelper.getReadableDatabase();
 
     Cursor cursor = db.query(DatabaseHelper.TABLE_NAME_BOOK_NOTE_LNK,
-                             new String[] {DatabaseHelper.BOOK_ID},
-                             DatabaseHelper.NOTE_ID + "=?",
-                             new String[] {String.valueOf(noteId)},
-                             null, null, null, String.valueOf(1));
+        new String[] {DatabaseHelper.BOOK_ID},
+        DatabaseHelper.NOTE_ID + "=?",
+        new String[] {String.valueOf(noteId)},
+        null, null, null, String.valueOf(1));
 
     Long bookId = 0L;
     if (cursor.moveToFirst()) {

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
@@ -247,7 +247,11 @@ public class NoteDao implements InterfaceNoteDao {
    * @return returns the notes text value without formatting texts
    */
   public String findStrippedTextById(Long id) {
-    return findTextById(id).replaceAll("<[^>]+>", "");
+    return findTextById(id).replaceAll(
+        "(<p dir=\"ltr\" style=\"margin-top:0; margin-bottom:0;\">|<\\/p>|" +
+            "<span style=\"text-decoration:line-through;\">|<\\/span>|<(\\/)?i>|" +
+            "<(\\/)?b>|<(\\/)?u>|<(\\/)?br>|<(\\/)?blockquote>)",
+        "");
   }
 
   private Note createNoteData(Cursor cursor) {

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * NoteDao contains all sql queries related to Note.
  *
- * @author Sarah Kurek, Claudia Schönherr
+ * @author Sarah Kurek, Claudia Schönherr, Luis Moßburger
  */
 public class NoteDao implements InterfaceNoteDao {
 
@@ -238,6 +238,33 @@ public class NoteDao implements InterfaceNoteDao {
     cursor.close();
 
     return noteText;
+  }
+
+  /**
+   * This method gets text string of a specific note without formatting xml tags.
+   *
+   * @param id id of the note to look for
+   * @return returns the notes text value
+   */
+  public String findStrippedTextById(Long id) {
+    SQLiteDatabase db = dbHelper.getReadableDatabase();
+
+    Cursor cursor = db.query(DatabaseHelper.TABLE_NAME_NOTE,
+        new String[] {DatabaseHelper._ID, DatabaseHelper.NAME,
+            DatabaseHelper.TYPE, DatabaseHelper.TEXT,
+            DatabaseHelper.CREATE_DATE, DatabaseHelper.MOD_DATE,
+            DatabaseHelper.NOTE_FILE_ID},
+        DatabaseHelper._ID + "=?", new String[] {String.valueOf(id)},
+        null, null, null, String.valueOf(1));
+
+    String noteText = null;
+    if (cursor.moveToFirst()) {
+      noteText = cursor.getString(3);
+    }
+
+    cursor.close();
+
+    return noteText.replaceAll("<[^>]+>", "");
   }
 
   private Note createNoteData(Cursor cursor) {

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
@@ -248,9 +248,9 @@ public class NoteDao implements InterfaceNoteDao {
    */
   public String findStrippedTextById(Long id) {
     return findTextById(id).replaceAll(
-        "(<p dir=\"ltr\" style=\"margin-top:0; margin-bottom:0;\">|<\\/p>|" +
-            "<span style=\"text-decoration:line-through;\">|<\\/span>|<(\\/)?i>|" +
-            "<(\\/)?b>|<(\\/)?u>|<(\\/)?br>|<(\\/)?blockquote>)",
+        "(<p dir=\"ltr\" style=\"margin-top:0; margin-bottom:0;\">|<\\/p>|"
+            + "<span style=\"text-decoration:line-through;\">|<\\/span>|<(\\/)?i>|"
+            + "<(\\/)?b>|<(\\/)?u>|<(\\/)?br>|<(\\/)?blockquote>)",
         "");
   }
 


### PR DESCRIPTION
**Description**
Closes #84.
Adds a new function which strips formatting tags from note text. This is used for the export function from now on.

**Affects**
Export function and Note.

**Notes for Reviewer**
Please review & comment/approve. Thanks!
See this example to review the new regex: https://regex101.com/r/V3CgIs/1