### PR TITLE
Fix overlapping note items (see Issue #146)

### DIFF
--- a/BibBuddy/app/src/main/java/de/bibbuddy/ImportBibTex.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/ImportBibTex.java
@@ -278,7 +278,7 @@ public class ImportBibTex {
         && !bibTagValue.get(BibTexKeys.ANNOTE).isEmpty()) {
 
       Note note = new Note(bibTagValue.get(BibTexKeys.BOOK_TITLE)
-          + " " + bibTagValue.get(BibTexKeys.AUTHOR), 0,
+          + " " + bibTagValue.get(BibTexKeys.AUTHOR), NoteTypeLut.TEXT,
           bibTagValue.get(BibTexKeys.ANNOTE));
 
       noteDao.create(note);

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -68,7 +68,7 @@ public class LibraryFragment extends Fragment
     view = inflater.inflate(R.layout.fragment_library, container, false);
     context = view.getContext();
 
-    sortCriteria = ((MainActivity) getActivity()).getSortCriteria();
+    sortCriteria = ((MainActivity) requireActivity()).getSortCriteria();
 
     setupRecyclerView();
     setupAddShelfBtn();
@@ -76,7 +76,7 @@ public class LibraryFragment extends Fragment
     ((MainActivity) requireActivity()).updateHeaderFragment(getString(R.string.navigation_library));
     ((MainActivity) requireActivity()).updateNavigationFragment(R.id.navigation_library);
 
-    ((MainActivity) getActivity()).setVisibilityImportShareButton(View.GONE, View.VISIBLE);
+    ((MainActivity) requireActivity()).setVisibilityImportShareButton(View.GONE, View.VISIBLE);
     setupSortBtn();
 
     setFunctionsToolbar();
@@ -94,8 +94,8 @@ public class LibraryFragment extends Fragment
   }
 
   private void setupSortBtn() {
-    ImageButton sortBtn = getActivity().findViewById(R.id.sort_btn);
-    ((MainActivity) getActivity()).setVisibilitySortButton(true);
+    ImageButton sortBtn = requireActivity().findViewById(R.id.sort_btn);
+    ((MainActivity) requireActivity()).setVisibilitySortButton(true);
 
     sortBtn.setOnClickListener(new View.OnClickListener() {
       @Override
@@ -107,7 +107,7 @@ public class LibraryFragment extends Fragment
 
   private void setFunctionsToolbar() {
 
-    ((MainActivity) getActivity()).shareBtn.setOnClickListener(new View.OnClickListener() {
+    ((MainActivity) requireActivity()).shareBtn.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View view) {
         checkEmptyLibrary();
@@ -150,7 +150,7 @@ public class LibraryFragment extends Fragment
         break;
 
       case R.id.menu_imprint:
-        ((MainActivity) getActivity()).openImprint();
+        ((MainActivity) requireActivity()).openImprint();
         break;
 
       default:
@@ -191,7 +191,7 @@ public class LibraryFragment extends Fragment
     bundle.putString(LibraryKeys.MANUAL_TEXT, htmlAsString);
     helpFragment.setArguments(bundle);
 
-    getActivity().getSupportFragmentManager().beginTransaction()
+    requireActivity().getSupportFragmentManager().beginTransaction()
         .replace(R.id.fragment_container_view, helpFragment,
             LibraryKeys.FRAGMENT_HELP_VIEW)
         .addToBackStack(null)
@@ -346,7 +346,7 @@ public class LibraryFragment extends Fragment
   }
 
   private void deselectLibraryItems() {
-    SwipeableRecyclerView shelfListView = getView().findViewById(R.id.library_recycler_view);
+    SwipeableRecyclerView shelfListView = requireView().findViewById(R.id.library_recycler_view);
     for (int i = 0; i < shelfListView.getChildCount(); i++) {
       shelfListView.getChildAt(i).setSelected(false);
     }
@@ -360,7 +360,7 @@ public class LibraryFragment extends Fragment
           @Override
           public void onSortedSelected(SortCriteria newSortCriteria) {
             sortCriteria = newSortCriteria;
-            ((MainActivity) getActivity()).setSortCriteria(newSortCriteria);
+            ((MainActivity) requireActivity()).setSortCriteria(newSortCriteria);
             sortLibraryList();
           }
         });
@@ -465,7 +465,7 @@ public class LibraryFragment extends Fragment
     BookFragment fragment = new BookFragment();
     fragment.setArguments(createShelfBundle(libraryItem));
 
-    getActivity().getSupportFragmentManager().beginTransaction()
+    requireActivity().getSupportFragmentManager().beginTransaction()
         .replace(R.id.fragment_container_view, fragment)
         .setReorderingAllowed(true)
         .addToBackStack(null)
@@ -508,7 +508,7 @@ public class LibraryFragment extends Fragment
         exportBibTex.getBibDataLibrary(libraryModel, bookDao, noteDao));
 
     Intent shareLibraryIntent =
-        ShareCompat.IntentBuilder.from(getActivity())
+        ShareCompat.IntentBuilder.from(requireActivity())
             .setStream(contentUri)
             .setType("text/*")
             .getIntent()

--- a/BibBuddy/app/src/main/java/de/bibbuddy/Note.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/Note.java
@@ -8,7 +8,7 @@ package de.bibbuddy;
 public class Note {
 
   private final String name;
-  private final Integer type;
+  private final NoteTypeLut type;
   private final String text;
   private Long id;
   private Long createDate;
@@ -23,7 +23,7 @@ public class Note {
    * @param type type of the note object (text, voice or picture)
    * @param text text content of the note object (as long as it is a type "text")
    */
-  public Note(String name, Integer type, String text) {
+  public Note(String name, NoteTypeLut type, String text) {
     this.name = name;
     this.type = type;
     this.text = text;
@@ -36,7 +36,7 @@ public class Note {
    * @param type         type of the note object (text, voice or picture)
    * @param noteFilePath path to the file of the note object
    */
-  public Note(String name, Integer type, String text, String noteFilePath) {
+  public Note(String name, NoteTypeLut type, String text, String noteFilePath) {
     this.name = name;
     this.type = type;
     this.text = text;
@@ -55,7 +55,7 @@ public class Note {
    * @param modDate    modification date of the note object
    * @param noteFileId id of the noteFile object contained in the note object
    */
-  public Note(Long id, String name, Integer type, String text, Long createDate, Long modDate,
+  public Note(Long id, String name, NoteTypeLut type, String text, Long createDate, Long modDate,
               Long noteFileId) {
     this.id = id;
     this.name = name;
@@ -74,7 +74,7 @@ public class Note {
     return name;
   }
 
-  public Integer getType() {
+  public NoteTypeLut getType() {
     return type;
   }
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteAudioItem.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteAudioItem.java
@@ -8,8 +8,13 @@ package de.bibbuddy;
  */
 public class NoteAudioItem extends NoteItem {
 
-  public NoteAudioItem(Long modDate, String name, Long id, Long bookId) {
-    super(modDate, name, R.drawable.microphone, id, bookId);
+  public NoteAudioItem(Note note, Long bookId) {
+    super(note, R.drawable.microphone, bookId);
+  }
+
+  @Override
+  public String getDisplayName() {
+    return "";
   }
 
 }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
@@ -40,7 +40,7 @@ public class NoteDao implements InterfaceNoteDao {
 
         ContentValues noteValues = new ContentValues();
         noteValues.put(DatabaseHelper.NAME, note.getName());
-        noteValues.put(DatabaseHelper.TYPE, note.getType()); // LUT !?
+        noteValues.put(DatabaseHelper.TYPE, note.getType().getId());
         noteValues.put(DatabaseHelper.TEXT, note.getText());
         noteValues.put(DatabaseHelper.CREATE_DATE, currentTime);
         noteValues.put(DatabaseHelper.MOD_DATE, currentTime);
@@ -282,7 +282,7 @@ public class NoteDao implements InterfaceNoteDao {
     return new Note(
         Long.parseLong(cursor.getString(0)), // Id
         cursor.getString(1), // Name
-        Integer.parseInt(cursor.getString(2)), // Type
+        NoteTypeLut.valueOf(Integer.parseInt(cursor.getString(2))), // Type
         cursor.getString(3), // Text
         Long.parseLong(cursor.getString(4)), // Create date
         Long.parseLong(cursor.getString(5)), // Mod date

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteItem.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteItem.java
@@ -6,41 +6,33 @@ package de.bibbuddy;
  *
  * @author Sarah Kurek
  */
-public class NoteItem implements SortableItem {
+public abstract class NoteItem implements SortableItem {
 
-  private final Long modDate;
-  private final String name;
+  private final Note note;
   private final int image;
-  private final Long id;
   private final Long bookId;
-  private final String modDateStr;
 
   /**
    * Constructor to set up a NoteItem for view/UI usages.
    *
-   * @param modDate string-value of the modification date of the note
-   * @param name    name of the note
+   * @param note    the note
    * @param image   id for the drawable resource of the note type icon
-   * @param id      id of the note
    * @param bookId  id of the book that the note is connected to
    */
-  public NoteItem(Long modDate, String name, int image, Long id, Long bookId) {
-    this.modDate = modDate;
-    this.modDateStr = DateConverter.convertDateToString(modDate);
-    this.name = name;
+  public NoteItem(Note note, int image, Long bookId) {
+    this.note = note;
     this.image = image;
-    this.id = id;
     this.bookId = bookId;
   }
 
   @Override
   public Long getModDate() {
-    return modDate;
+    return note.getModDate();
   }
 
   @Override
   public String getName() {
-    return name;
+    return note.getName();
   }
 
   public int getImage() {
@@ -48,7 +40,11 @@ public class NoteItem implements SortableItem {
   }
 
   public Long getId() {
-    return id;
+    return note.getId();
+  }
+
+  public NoteTypeLut getType() {
+    return note.getType();
   }
 
   public Long getBookId() {
@@ -56,7 +52,9 @@ public class NoteItem implements SortableItem {
   }
 
   public String getModDateStr() {
-    return modDateStr;
+    return DateConverter.convertDateToString(getModDate());
   }
+
+  public abstract String getDisplayName();
 
 }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteRecyclerViewAdapter.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteRecyclerViewAdapter.java
@@ -94,20 +94,19 @@ public class NoteRecyclerViewAdapter
   @Override
   public void onBindViewHolder(@NonNull NotesViewHolder holder, int position) {
     NoteItem noteItem = noteList.get(position);
-    int image = noteItem.getImage();
 
     setupBasicCardView(holder, position);
-    if (noteItem.getImage() == R.drawable.microphone) {
+
+    if (noteItem.getType() == NoteTypeLut.AUDIO) {
       setupAudioElements(holder, noteItem);
     }
 
     holder.itemView.setOnClickListener(v -> {
-      if (getSelectedNoteItems().size() > 0) {
+      if (!getSelectedNoteItems().isEmpty()) {
         v.setSelected(!v.isSelected());
       } else {
-        if (image == R.drawable.document) {
+        if (noteItem.getType() == NoteTypeLut.TEXT) {
           TextNoteEditorFragment nextFrag = new TextNoteEditorFragment();
-
           nextFrag.setArguments(createNoteBundle(noteItem));
 
           activity.getSupportFragmentManager().beginTransaction()
@@ -138,15 +137,18 @@ public class NoteRecyclerViewAdapter
   }
 
   private void setupBasicCardView(NotesViewHolder holder, int position) {
+    holder.itemView.findViewById(R.id.voice_note_layout).setVisibility(View.GONE);
+
     NoteItem noteItem = noteList.get(position);
     holder.getModDateView().setText(noteItem.getModDateStr());
-    holder.getNameView().setText(noteItem.getName());
+    holder.getNameView().setText(noteItem.getDisplayName());
     holder.getTypeView().setImageDrawable(ContextCompat.getDrawable(activity.getBaseContext(),
         noteItem.getImage()));
   }
 
   private void setupAudioElements(NotesViewHolder holder, NoteItem noteItem) {
     holder.itemView.findViewById(R.id.voice_note_layout).setVisibility(View.VISIBLE);
+
     ImageButton playButton = holder.getPlayNoteButton();
     playButtons.add(playButton);
     playButton.setVisibility(View.VISIBLE);

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteTextItem.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteTextItem.java
@@ -21,7 +21,6 @@ public class NoteTextItem extends NoteItem {
   public NoteTextItem(Note note, Long bookId) {
     super(note, R.drawable.document, bookId);
 
-
     String name = note.getName();
     name = Jsoup.parse(name).text();
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteTextItem.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteTextItem.java
@@ -1,5 +1,7 @@
 package de.bibbuddy;
 
+import org.jsoup.Jsoup;
+
 /**
  * The NoteTextItem is responsible for holding the information of the note text items.
  * It is a child of NoteItem.
@@ -8,8 +10,31 @@ package de.bibbuddy;
  */
 public class NoteTextItem extends NoteItem {
 
-  public NoteTextItem(Long modDate, String name, Long id, Long bookId) {
-    super(modDate, name, R.drawable.document, id, bookId);
+  private final String displayName;
+
+  /**
+   * Constructor to set up a new noteTextItem.
+   *
+   * @param note   note object
+   * @param bookId id of the related book
+   */
+  public NoteTextItem(Note note, Long bookId) {
+    super(note, R.drawable.document, bookId);
+
+
+    String name = note.getName();
+    name = Jsoup.parse(name).text();
+
+    if (name.length() > 20) {
+      name = name.substring(0, 20) + " ...";
+    }
+
+    this.displayName = name;
+  }
+
+  @Override
+  public String getDisplayName() {
+    return displayName;
   }
 
 }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteTypeLut.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteTypeLut.java
@@ -1,5 +1,7 @@
 package de.bibbuddy;
 
+import java.util.stream.Stream;
+
 /**
  * Look up table for the note type.
  *
@@ -11,6 +13,13 @@ public enum NoteTypeLut {
 
   private final int id;
 
+  static NoteTypeLut valueOf(int id) {
+    return Stream.of(NoteTypeLut.values())
+      .filter(e -> e.getId() == id)
+      .findFirst()
+      .orElseThrow(IllegalArgumentException::new);
+  }
+
   NoteTypeLut(int id) {
     this.id = id;
   }
@@ -18,4 +27,5 @@ public enum NoteTypeLut {
   public int getId() {
     return id;
   }
+
 }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/TextNoteEditorFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/TextNoteEditorFragment.java
@@ -127,7 +127,7 @@ public class TextNoteEditorFragment extends Fragment {
       if (getArguments().size() == 2) {
         noteModel.updateNote(note, name, text);
       } else {
-        noteModel.createNote(name, 0, text, "");
+        noteModel.createNote(name, NoteTypeLut.TEXT, text, "");
         noteModel.linkNoteWithBook(bookId, noteModel.getLastNote().getId());
       }
     }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/VoiceNoteEditorFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/VoiceNoteEditorFragment.java
@@ -158,7 +158,7 @@ public class VoiceNoteEditorFragment extends Fragment {
     Long currentTime = new Date().getTime();
     String fileName =
         getString(R.string.voice_note_name) + DateConverter.convertDateToString(currentTime);
-    noteModel.createNote(fileName, 1, "", newAudio.getPath());
+    noteModel.createNote(fileName, NoteTypeLut.AUDIO, "", newAudio.getPath());
     noteModel.linkNoteWithBook(bookId, noteModel.getLastNote().getId());
     Toast.makeText(requireActivity(), getString(R.string.voice_note_saved), Toast.LENGTH_SHORT)
         .show();


### PR DESCRIPTION
**Description**
Closes #146.
Fixing the overlapping NoteItems after deleting an item. Visibility of the Note Audio elements was corrected. 
The existing enum was used for the NoteType so that there are no magic numbers in the code and errors are avoided. 
Also the code has been cleaned up a bit.

**Affects**
NotesFragment, BookNotesView, NoteTypeLut

**Notes for Reviewer**
Please review & comment/approve. Thanks!