### PR TITLE
Bugfixes author retrieval & note export

### DIFF
--- a/BibBuddy/app/src/main/java/de/bibbuddy/AuthorRetriever.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/AuthorRetriever.java
@@ -113,8 +113,19 @@ public class AuthorRetriever {
       Object exprResult = expr.evaluate(xmlMetadata, XPathConstants.NODESET);
       NodeList authorNameWrapper = (NodeList) exprResult;
       String authorName = authorNameWrapper.item(0).getTextContent();
-      // MARCXML datafield "100" subfield code "a" is always in this form: Lastname, First Name
-      author = new Author(authorName.split(",")[1].trim(), authorName.split(",")[0].trim());
+
+      // MARCXML datafield "100" subfield code "a" normally is in this form: Lastname, First Name
+      // In some cases, the person has a "Eigenname", like "Marc Aurel" and therefore no comma
+      // In that case, we split by the last space in the name
+      if (authorName.contains(",")) {
+        author = new Author(authorName.split(",")[1].trim(), authorName.split(",")[0].trim());
+      } else if (authorName.contains(" ")) {
+        int posOfLastSpace = authorName.lastIndexOf(" ");
+        author = new Author(authorName.substring(0, posOfLastSpace).trim(),
+            authorName.substring(posOfLastSpace).trim());
+      } else {
+        author = new Author(authorName, " ");
+      }
     } catch (Exception e) {
       System.out.println(e);
     }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
@@ -366,7 +366,7 @@ public class NoteDao implements InterfaceNoteDao {
 
     Cursor cursor = db.rawQuery(selectQuery, new String[] {String.valueOf(NoteTypeLut.TEXT.getId()),
         String.valueOf(bookId)
-      });
+        });
 
     List<Long> noteIds = new ArrayList<>();
     if (cursor.moveToFirst()) {

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
@@ -250,12 +250,12 @@ public class NoteDao implements InterfaceNoteDao {
     SQLiteDatabase db = dbHelper.getReadableDatabase();
 
     Cursor cursor = db.query(DatabaseHelper.TABLE_NAME_NOTE,
-                             new String[] {DatabaseHelper._ID, DatabaseHelper.NAME,
-                                 DatabaseHelper.TYPE, DatabaseHelper.TEXT,
-                                 DatabaseHelper.CREATE_DATE, DatabaseHelper.MOD_DATE,
-                                 DatabaseHelper.NOTE_FILE_ID},
-                             DatabaseHelper._ID + "=?", new String[] {String.valueOf(id)},
-                             null, null, null, String.valueOf(1));
+        new String[] {DatabaseHelper._ID, DatabaseHelper.NAME,
+            DatabaseHelper.TYPE, DatabaseHelper.TEXT,
+            DatabaseHelper.CREATE_DATE, DatabaseHelper.MOD_DATE,
+            DatabaseHelper.NOTE_FILE_ID},
+        DatabaseHelper._ID + "=?", new String[] {String.valueOf(id)},
+        null, null, null, String.valueOf(1));
 
     String noteText = null;
     if (cursor.moveToFirst()) {
@@ -274,7 +274,12 @@ public class NoteDao implements InterfaceNoteDao {
    * @return returns the notes text value without formatting texts
    */
   public String findStrippedTextById(Long id) {
-    return findTextById(id).replaceAll("<.*?>", "");
+    return findTextById(id).replaceAll(
+        "(<p dir=\"ltr\"( style=\"margin-top:0; margin-bottom:0;\")?>|</p>|"
+            + "<div align=\"right\"  >|<div align=\"center\"  >|</div>|"
+            + "<span style=\"text-decoration:line-through;\">|</span>|<(/)?i>|"
+            + "<(/)?b>|<(/)?u>|<(/)?br>|<(/)?blockquote>)",
+        "");
   }
 
   private Note createNoteData(Cursor cursor) {
@@ -361,7 +366,7 @@ public class NoteDao implements InterfaceNoteDao {
 
     Cursor cursor = db.rawQuery(selectQuery, new String[] {String.valueOf(NoteTypeLut.TEXT.getId()),
         String.valueOf(bookId)
-        });
+      });
 
     List<Long> noteIds = new ArrayList<>();
     if (cursor.moveToFirst()) {


### PR DESCRIPTION
**Description**
Two bugfixes, closing #84 and #158.
New elements for note styling had to be considered in the respective regex for the note export - the regex was wrongly altered and simplified in PR #147. That was undone, was we discussed that with such a regex, "<>" wanted by the user would be stripped as well (#84).
A bug with author retrieval for "Eigennamen" like "Marc Aurel" had to be fixed (#158).

**Affects**
Note export & author retrieval.

**Notes for Reviewer**
Please review & comment/approve. Thanks!