### PR TITLE
Cleanup Import, LibraryFragment (see Issue #152)

### DIFF
--- a/BibBuddy/app/src/main/java/de/bibbuddy/BibTexKeys.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/BibTexKeys.java
@@ -26,5 +26,6 @@ public class BibTexKeys {
   public static final String OPENING_CURLY_BRACKET = "{";
   public static final String CLOSING_CURLY_BRACKET = "}";
   public static final String COMMA_SEPARATOR = ",";
+  public static final String EQUAL_SIGN = "=";
 
 }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/BookFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/BookFragment.java
@@ -36,6 +36,7 @@ import com.tsuryo.swipeablerv.SwipeableRecyclerView;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The BookFragment is responsible for the current books of a shelf in the library.
@@ -53,8 +54,7 @@ public class BookFragment extends BackStackFragment implements BookRecyclerViewA
   private NoteModel noteModel;
 
   private BookRecyclerViewAdapter adapter;
-  private BookDao bookDao;
-  private NoteDao noteDao;
+
   private SortCriteria sortCriteria;
   private ExportBibTex exportBibTex;
   private ImportBibTex importBibTex;
@@ -70,7 +70,8 @@ public class BookFragment extends BackStackFragment implements BookRecyclerViewA
                 if (data != null) {
                   Uri uri = data.getData();
 
-                  if (importBibTex.isBibFile(UriUtils.getFullUriPath(context, uri))) {
+                  if (importBibTex.isBibFile(
+                      Objects.requireNonNull(UriUtils.getFullUriPath(context, uri)))) {
                     handleImport(uri);
                   } else {
                     showDialogNonBibFile();
@@ -125,10 +126,7 @@ public class BookFragment extends BackStackFragment implements BookRecyclerViewA
     List<BookItem> bookList;
     bookList = bookModel.getBookList(shelfId);
 
-    bookDao = bookModel.getBookDao();
-    noteDao = bookModel.getNoteDao();
-
-    exportBibTex = new ExportBibTex(StorageKeys.DOWNLOAD_FOLDER, shelfName);
+    exportBibTex = new ExportBibTex(shelfName);
     importBibTex = new ImportBibTex(context);
 
     SwipeableRecyclerView recyclerView = view.findViewById(R.id.book_recycler_view);
@@ -364,16 +362,13 @@ public class BookFragment extends BackStackFragment implements BookRecyclerViewA
   }
 
   private void checkEmptyShelf() {
-    if (bookDao.getAllBooksForShelf(shelfId).isEmpty()) {
+    if (bookModel.getAllBooksForShelf(shelfId).isEmpty()) {
       AlertDialog.Builder alertDialogEmptyShelf = new AlertDialog.Builder(getContext());
       alertDialogEmptyShelf.setTitle(R.string.empty_shelf);
       alertDialogEmptyShelf.setMessage(R.string.empty_shelf_description);
 
       alertDialogEmptyShelf.setPositiveButton(R.string.ok,
-          new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-            }
+          (dialog, which) -> {
           });
 
       alertDialogEmptyShelf.create().show();
@@ -426,13 +421,11 @@ public class BookFragment extends BackStackFragment implements BookRecyclerViewA
   }
 
   private String readBibFile(Uri uri) {
+
     try {
 
-      if (importBibTex.readTextFromUri(uri) != null) {
-        return importBibTex.readTextFromUri(uri);
-      } else {
-        return null;
-      }
+      importBibTex.readTextFromUri(uri);
+      return importBibTex.readTextFromUri(uri);
 
     } catch (IOException e) {
       e.printStackTrace();
@@ -656,8 +649,10 @@ public class BookFragment extends BackStackFragment implements BookRecyclerViewA
 
   private void shareShelfBibIntent() {
 
-    Uri contentUri = exportBibTex.writeTemporaryBibFile(context,
-        exportBibTex.getBibDataFromShelf(shelfId, bookDao, noteDao));
+    String bibContent =
+        exportBibTex.getBibDataFromShelf(shelfId, bookModel, noteModel);
+
+    Uri contentUri = exportBibTex.writeTemporaryBibFile(context, bibContent);
 
     Intent shareShelfIntent =
         ShareCompat.IntentBuilder.from(requireActivity())

--- a/BibBuddy/app/src/main/java/de/bibbuddy/BookModel.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/BookModel.java
@@ -34,12 +34,34 @@ public class BookModel {
     this.noteDao = new NoteDao(databaseHelper);
   }
 
-  public BookDao getBookDao() {
-    return bookDao;
+  /**
+   * Gets all books from the databse.
+   *
+   * @return a list with objects of the class Book
+   */
+  public List<Book> getAllBooks() {
+    return bookDao.findAllBooks();
   }
 
-  public NoteDao getNoteDao() {
-    return noteDao;
+  /**
+   * Gets all books for a shelf with given id.
+   *
+   * @param id       id of a shelf
+   * @return         a list from type Book
+   *                 with all books from a given shelf
+   */
+  public List<Book> getAllBooksForShelf(Long id) {
+    return bookDao.getAllBooksForShelf(id);
+  }
+
+  /**
+   * Gets all book Ids from a shelf with given ID.
+   *
+   * @param id    id of a shelf
+   * @return      a list with all book ids from a given shelf
+   */
+  public List<Long> getAllBookIdsForShelf(Long id) {
+    return bookDao.getAllBookIdsForShelf(id);
   }
 
   private String convertAuthorListToString(List<Author> authorList) {

--- a/BibBuddy/app/src/main/java/de/bibbuddy/BookNotesView.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/BookNotesView.java
@@ -107,8 +107,9 @@ public class BookNotesView extends BackStackFragment implements SwipeLeftRightCa
     bookModel = new BookModel(requireContext(), getShelfId());
     noteModel = new NoteModel(requireContext());
 
-    String fileName = (bookModel.getBookById(bookId).getTitle()
-        + bookModel.getBookById(bookId).getPubYear())
+    Book book = bookModel.getBookById(bookId);
+
+    String fileName = (book.getTitle() + book.getPubYear())
         .replaceAll("\\s+", "");
     exportBibTex = new ExportBibTex(fileName);
 
@@ -125,6 +126,7 @@ public class BookNotesView extends BackStackFragment implements SwipeLeftRightCa
 
   private Long getShelfId() {
     Bundle bundle = this.getArguments();
+    assert bundle != null;
     return bundle.getLong(LibraryKeys.SHELF_ID);
   }
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/ExportBibTex.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/ExportBibTex.java
@@ -100,6 +100,7 @@ public class ExportBibTex {
     Book book = bookModel.getBookById(bookId);
 
     return BibTexKeys.BOOK_TAG + BibTexKeys.OPENING_CURLY_BRACKET + getBibKey(book)
+        + BibTexKeys.COMMA_SEPARATOR + "\n"
 
         + BibTexKeys.ISBN + BibTexKeys.OPENING_CURLY_BRACKET + book.getIsbn()
         + BibTexKeys.CLOSING_CURLY_BRACKET + BibTexKeys.COMMA_SEPARATOR + "\n"
@@ -128,7 +129,7 @@ public class ExportBibTex {
   private String getBibKey(Book book) {
     // remove whitespaces from book's title
     return book.getTitle().replaceAll("\\s+",
-        "") + "," + "\n";
+        "");
   }
 
   private String getBibNotesFromBook(Book book, NoteModel noteModel) {
@@ -152,7 +153,8 @@ public class ExportBibTex {
     StringBuilder authorNames = new StringBuilder();
 
     for (int i = 0; i < authorsList.size(); i++) {
-      authorNames.append(authorsList.get(i).getLastName()).append(", ")
+      authorNames.append(authorsList.get(i).getLastName())
+          .append(BibTexKeys.COMMA_SEPARATOR + " ")
           .append(authorsList.get(i).getFirstName());
 
       if (i < authorsList.size() - 1) {
@@ -174,7 +176,7 @@ public class ExportBibTex {
    *
    * @param context the context of the used fragment
    * @param content the content of temporary BibTeX file
-   * @return        the temporary file as URI
+   * @return the temporary file as URI
    */
   public Uri writeTemporaryBibFile(Context context, String content) {
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/ImportBibTex.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/ImportBibTex.java
@@ -132,8 +132,8 @@ public class ImportBibTex {
   private void removeEqualSignFromBibTag(String line) {
     for (String bibTag : bibTags) {
 
-      if (line.contains("=") && line.contains(bibTag)) {
-        line = line.replaceFirst("\\s*=\\s*", "=");
+      if (line.contains(BibTexKeys.EQUAL_SIGN) && line.contains(bibTag)) {
+        line = line.replaceFirst("\\s*=\\s*", BibTexKeys.EQUAL_SIGN);
       }
 
     }
@@ -243,15 +243,19 @@ public class ImportBibTex {
   private void getAuthorNames(String authorNames, List<Author> authors) {
 
     // if the names are comma separated
-    if (authorNames.contains(", ")) {
-      String[] authorName = authorNames.split(", ");
+    if (authorNames.contains(BibTexKeys.COMMA_SEPARATOR + " ")) {
+      String[] authorName =
+          authorNames.split(BibTexKeys.COMMA_SEPARATOR + " ");
       authors.add(new Author(authorName[1], authorName[0], ""));
     }
 
     // if the names are whitespace separated
-    if (authorNames.contains(" ") && !authorNames.contains(", ")) {
+    if (authorNames.contains(" ")
+        && !authorNames.contains(BibTexKeys.COMMA_SEPARATOR + " ")) {
+
       String[] currentAuthorsNames = authorNames.split(" ", 2);
       authors.add(new Author(currentAuthorsNames[1], currentAuthorsNames[0], ""));
+
     }
 
   }

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -138,7 +138,7 @@ public class LibraryFragment extends BackStackFragment
   private void checkEmptyLibrary() {
     // if no shelf or no books
     if (libraryModel.getCurrentLibraryList().isEmpty() || bookModel.getAllBooks().isEmpty()) {
-      AlertDialog.Builder alertDialogEmptyLib = new AlertDialog.Builder(getContext());
+      AlertDialog.Builder alertDialogEmptyLib = new AlertDialog.Builder(requireContext());
       alertDialogEmptyLib.setTitle(R.string.empty_library);
       alertDialogEmptyLib.setMessage(R.string.empty_library_description);
 
@@ -327,7 +327,7 @@ public class LibraryFragment extends BackStackFragment
   }
 
   private void setupRecyclerView() {
-    libraryModel = new LibraryModel(getContext());
+    libraryModel = new LibraryModel(requireContext());
     List<ShelfItem> libraryList = libraryModel
         .getSortedLibraryList(sortCriteria, libraryModel.getLibraryList(null));
 

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryFragment.java
@@ -1,8 +1,8 @@
 package de.bibbuddy;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -15,12 +15,9 @@ import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.TextView;
 import android.widget.Toast;
-import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ShareCompat;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentManager;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.tsuryo.swipeablerv.SwipeLeftRightCallback;
 import com.tsuryo.swipeablerv.SwipeableRecyclerView;
@@ -41,8 +38,8 @@ public class LibraryFragment extends BackStackFragment
   private LibraryRecyclerViewAdapter adapter;
   private List<ShelfItem> selectedShelfItems = new ArrayList<>();
 
-  private BookDao bookDao;
-  private NoteDao noteDao;
+  private BookModel bookModel;
+  private NoteModel noteModel;
 
   private ExportBibTex exportBibTex;
   private SortCriteria sortCriteria;
@@ -82,11 +79,11 @@ public class LibraryFragment extends BackStackFragment
     setHasOptionsMenu(true);
 
     selectedShelfItems.clear();
-    bookDao = libraryModel.getBookDao();
-    noteDao = libraryModel.getNoteDao();
+    bookModel = new BookModel(requireContext(), libraryModel.getShelfId());
+    noteModel = new NoteModel(requireContext());
 
     String fileName = "library_export_BibBuddy";
-    exportBibTex = new ExportBibTex(StorageKeys.DOWNLOAD_FOLDER, fileName);
+    exportBibTex = new ExportBibTex(fileName);
 
     return view;
   }
@@ -97,21 +94,11 @@ public class LibraryFragment extends BackStackFragment
     ImageButton sortBtn = mainActivity.findViewById(R.id.sort_btn);
     mainActivity.setVisibilitySortButton(true);
 
-    sortBtn.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View v) {
-        handleSortShelf();
-      }
-    });
+    sortBtn.setOnClickListener(v -> handleSortShelf());
   }
 
   private void setFunctionsToolbar() {
-    ((MainActivity) requireActivity()).shareBtn.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View view) {
-        checkEmptyLibrary();
-      }
-    });
+    ((MainActivity) requireActivity()).shareBtn.setOnClickListener(view -> checkEmptyLibrary());
 
   }
 
@@ -121,6 +108,7 @@ public class LibraryFragment extends BackStackFragment
     super.onCreateOptionsMenu(menu, inflater);
   }
 
+  @SuppressLint("NonConstantResourceId")
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
     switch (item.getItemId()) {
@@ -149,16 +137,13 @@ public class LibraryFragment extends BackStackFragment
 
   private void checkEmptyLibrary() {
     // if no shelf or no books
-    if (libraryModel.getCurrentLibraryList().isEmpty() || bookDao.findAllBooks().isEmpty()) {
+    if (libraryModel.getCurrentLibraryList().isEmpty() || bookModel.getAllBooks().isEmpty()) {
       AlertDialog.Builder alertDialogEmptyLib = new AlertDialog.Builder(getContext());
       alertDialogEmptyLib.setTitle(R.string.empty_library);
       alertDialogEmptyLib.setMessage(R.string.empty_library_description);
 
       alertDialogEmptyLib.setPositiveButton(R.string.ok,
-          new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-            }
+          (dialog, which) -> {
           });
 
       alertDialogEmptyLib.create().show();
@@ -209,19 +194,11 @@ public class LibraryFragment extends BackStackFragment
       alertDeleteShelf.setTitle(R.string.delete_shelf);
     }
 
-    alertDeleteShelf.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
-      @Override
-      public void onClick(DialogInterface dialog, int which) {
-        deselectLibraryItems();
-      }
-    });
+    alertDeleteShelf.setNegativeButton(R.string.cancel, (dialog, which) -> deselectLibraryItems());
 
-    alertDeleteShelf.setPositiveButton(R.string.delete, new DialogInterface.OnClickListener() {
-      @Override
-      public void onClick(DialogInterface dialog, int which) {
-        performDeleteShelf();
-        deselectLibraryItems();
-      }
+    alertDeleteShelf.setPositiveButton(R.string.delete, (dialog, which) -> {
+      performDeleteShelf();
+      deselectLibraryItems();
     });
 
     alertDeleteShelf.show();
@@ -334,13 +311,10 @@ public class LibraryFragment extends BackStackFragment
 
   private void handleSortShelf() {
     SortDialog sortDialog = new SortDialog(context, sortCriteria,
-        new SortDialog.SortDialogListener() {
-          @Override
-          public void onSortedSelected(SortCriteria newSortCriteria) {
-            sortCriteria = newSortCriteria;
-            ((MainActivity) requireActivity()).setSortCriteria(newSortCriteria);
-            sortLibraryList();
-          }
+        newSortCriteria -> {
+          sortCriteria = newSortCriteria;
+          ((MainActivity) requireActivity()).setSortCriteria(newSortCriteria);
+          sortLibraryList();
         });
 
     sortDialog.show();
@@ -371,12 +345,7 @@ public class LibraryFragment extends BackStackFragment
   }
 
   private void createAddShelfListener(FloatingActionButton addShelfBtn) {
-    addShelfBtn.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View v) {
-        handleAddShelf();
-      }
-    });
+    addShelfBtn.setOnClickListener(v -> handleAddShelf());
   }
 
   private Bundle createAddShelfBundle() {
@@ -475,8 +444,8 @@ public class LibraryFragment extends BackStackFragment
 
   private void shareLibraryBibIntent() {
 
-    Uri contentUri = exportBibTex.writeTemporaryBibFile(context,
-        exportBibTex.getBibDataLibrary(libraryModel, bookDao, noteDao));
+    String content = exportBibTex.getBibDataLibrary(libraryModel, bookModel, noteModel);
+    Uri contentUri = exportBibTex.writeTemporaryBibFile(context, content);
 
     Intent shareLibraryIntent =
         ShareCompat.IntentBuilder.from(requireActivity())

--- a/BibBuddy/app/src/main/java/de/bibbuddy/LibraryModel.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/LibraryModel.java
@@ -32,14 +32,6 @@ public class LibraryModel {
     this.noteDao = new NoteDao(databaseHelper);
   }
 
-  public BookDao getBookDao() {
-    return bookDao;
-  }
-
-  public NoteDao getNoteDao() {
-    return noteDao;
-  }
-
   /**
    * Adds a new book to the bookList and database.
    *

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteDao.java
@@ -267,21 +267,6 @@ public class NoteDao implements InterfaceNoteDao {
     return noteText;
   }
 
-  /**
-   * This method gets text string of a specific note without formatting xml tags.
-   *
-   * @param id id of the note to look for
-   * @return returns the notes text value without formatting texts
-   */
-  public String findStrippedTextById(Long id) {
-    return findTextById(id).replaceAll(
-        "(<p dir=\"ltr\"( style=\"margin-top:0; margin-bottom:0;\")?>|</p>|"
-            + "<div align=\"right\"  >|<div align=\"center\"  >|</div>|"
-            + "<span style=\"text-decoration:line-through;\">|</span>|<(/)?i>|"
-            + "<(/)?b>|<(/)?u>|<(/)?br>|<(/)?blockquote>)",
-        "");
-  }
-
   private Note createNoteData(Cursor cursor) {
 
     return new Note(
@@ -364,9 +349,9 @@ public class NoteDao implements InterfaceNoteDao {
         + " n ON (n." + DatabaseHelper._ID + " = lnk." + DatabaseHelper.NOTE_ID + ")"
         + " WHERE n." + DatabaseHelper.TYPE + " = ? AND lnk." + DatabaseHelper.BOOK_ID + "= ?";
 
-    Cursor cursor = db.rawQuery(selectQuery, new String[] {String.valueOf(NoteTypeLut.TEXT.getId()),
-        String.valueOf(bookId)
-        });
+    Cursor cursor = db.rawQuery(selectQuery, new String[] {
+        String.valueOf(NoteTypeLut.TEXT.getId()),
+        String.valueOf(bookId) });
 
     List<Long> noteIds = new ArrayList<>();
     if (cursor.moveToFirst()) {

--- a/BibBuddy/app/src/main/java/de/bibbuddy/NoteModel.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/NoteModel.java
@@ -20,6 +20,31 @@ public class NoteModel {
   }
 
   /**
+   * This method gets the Ids of all notes for a given book.
+   *
+   * @param id      id of a book
+   * @return        a list with the Ids of all text notes
+   */
+  public List<Long> getTextNoteIdsForBook(Long id) {
+    return noteDao.getTextNoteIdsForBook(id);
+  }
+
+  /**
+   * This method gets text string of a specific note without formatting xml tags.
+   *
+   * @param id   id of the note to look for
+   * @return     returns the notes text value without formatting texts
+   */
+  public String findStrippedTextById(Long id) {
+    return noteDao.findTextById(id).replaceAll(
+        "(<p dir=\"ltr\"( style=\"margin-top:0; margin-bottom:0;\")?>|</p>|"
+            + "<div align=\"right\"  >|<div align=\"center\"  >|</div>|"
+            + "<span style=\"text-decoration:line-through;\">|</span>|<(/)?i>|"
+            + "<(/)?b>|<(/)?u>|<(/)?br>|<(/)?blockquote>)",
+        "");
+  }
+
+  /**
    * Creates a note object and pass it to the noteDao to add it to the database as well.
    *
    * @param name         of the note object.

--- a/BibBuddy/app/src/main/java/de/bibbuddy/UriUtils.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/UriUtils.java
@@ -243,7 +243,7 @@ public class UriUtils {
 
       try {
         return getDataColumn(context, ContentUris.withAppendedId(Uri.parse(contentUriPrefix),
-            Long.valueOf(id)), null, null);
+            Long.parseLong(id)), null, null);
 
       } catch (NumberFormatException e) {
         return uri.getPath().replaceFirst(UriUtilsKeys.PREFIX_DOCUMENT_RAW, "")

--- a/BibBuddy/app/src/main/java/de/bibbuddy/UriUtilsKeys.java
+++ b/BibBuddy/app/src/main/java/de/bibbuddy/UriUtilsKeys.java
@@ -1,7 +1,7 @@
 package de.bibbuddy;
 
 /**
- * Constants used in the UriUtility class.
+ * Constants used in the UriUtils class.
  *
  * @author Silvia Ivanova
  */


### PR DESCRIPTION
**Description**
Code cleanup for:

- ImportBibTex-Class and related classes (UriUrils, UriUtilsKeys)
- BibTexKeys
- LibraryFragment 

Used lambda functions when it is suggested by Android Studio.  
Used BookModel and NoteModel instead of BookDao and NoteDao respectively.
As suggested in my previous PR by Sabrina, used requireContext() instead of getContext() to avoid NullPointerExceptions. (See PR #157 )
Reformulated some comments for consistency. 
Removed unused code.
**Android Studio's suggestions have been taken into account.**

**Affects**
ImportBibTex-Class and related classes (UriUrils, UriUtilsKeys), BibTexKeys & LibraryFragment 

**Notes for Reviewer**
Please review & comment/approve. Thanks!